### PR TITLE
add slack client for slack messages search count

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,12 @@
 module github.com/crowdworks/slacts
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gorilla/websocket v1.4.0 // indirect
+	github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5 // indirect
+	github.com/lusis/slack-test v0.0.0-20180109053238-3c758769bfa6 // indirect
+	github.com/nlopes/slack v0.4.0
+	github.com/pkg/errors v0.8.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.2.2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
+github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5 h1:AsEBgzv3DhuYHI/GiQh2HxvTP71HCCE9E/tzGUzGdtU=
+github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5/go.mod h1:c2mYKRyMb1BPkO5St0c/ps62L4S0W2NAkaTXj9qEI+0=
+github.com/lusis/slack-test v0.0.0-20180109053238-3c758769bfa6 h1:iOAVXzZyXtW408TMYejlUPo6BIn92HmOacWtIfNyYns=
+github.com/lusis/slack-test v0.0.0-20180109053238-3c758769bfa6/go.mod h1:sFlOUpQL1YcjhFVXhg1CG8ZASEs/Mf1oVb6H75JL/zg=
+github.com/nlopes/slack v0.4.0 h1:OVnHm7lv5gGT5gkcHsZAyw++oHVFihbjWbL3UceUpiA=
+github.com/nlopes/slack v0.4.0/go.mod h1:jVI4BBK3lSktibKahxBF74txcK2vyvkza1z/+rRnVAM=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/slack.go
+++ b/slack.go
@@ -1,0 +1,43 @@
+package slacts
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/nlopes/slack"
+)
+
+type SlackRequester interface {
+	SearchMessagesContext(context.Context, string, slack.SearchParameters) (*slack.SearchMessages, error)
+}
+
+type SlackClient struct {
+	Client SlackRequester
+}
+
+// NewSlackClient returns SlackClient object.
+// arg httpclient for using custom http.Client. So this can be nil.
+//
+// For example,
+// 	NewSlackClient('YOUR_TOKEN', urlfetch.Client(ctx))
+func NewSlackClient(token string, httpclient *http.Client) *SlackClient {
+	var opts []slack.Option
+
+	if httpclient != nil {
+		opts = []slack.Option{slack.OptionHTTPClient(httpclient)}
+	}
+
+	return &SlackClient{
+		Client: slack.New(token, opts...),
+	}
+}
+
+// CountQuery returns count of matches with query
+func (sc *SlackClient) CountQuery(ctx context.Context, query string) (int, error) {
+	res, err := sc.Client.SearchMessagesContext(ctx, query, slack.SearchParameters{})
+	if err != nil {
+		return 0, err
+	}
+
+	return res.Total, nil
+}

--- a/slack_test.go
+++ b/slack_test.go
@@ -1,0 +1,36 @@
+package slacts_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/crowdworks/slacts"
+	"github.com/nlopes/slack"
+)
+
+type testSlackClient struct{}
+
+func (tsc *testSlackClient) SearchMessagesContext(ctx context.Context, q string, params slack.SearchParameters) (*slack.SearchMessages, error) {
+	sm := &slack.SearchMessages{
+		Total: 27,
+	}
+
+	return sm, nil
+}
+
+func TestSlackClient_CountQuery(t *testing.T) {
+	ctx := context.Background()
+
+	sc := slacts.SlackClient{
+		Client: new(testSlackClient),
+	}
+
+	count, err := sc.CountQuery(ctx, "in:general channel")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if count != 27 {
+		t.Errorf("query count expected 27 but actual %d", count)
+	}
+}


### PR DESCRIPTION
Add slack client for slack messages search count.
Rely on [nlopes/slack](https://github.com/nlopes/slack)

Consider following points

* be able to change `http.Client` for GAE and other cases...
* use interface when using `nlopes/slack` because of testability