### PR TITLE
static analytics at CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
         name: Install linters
         command: |
           go get golang.org/x/tools/cmd/goimports
+          go get golang.org/x/lint/golint
     - save_cache:
         name: Save go modules cache
         key: mod-{{ .Environment.COMMON_CACHE_KEY }}-{{ checksum "go.mod" }}
@@ -30,6 +31,9 @@ jobs:
     - run:
         name: Exec goimports
         command: test -z "$(goimports -l . | tee /dev/stderr)"
+    - run:
+        name: Exec golint
+        command: test -z "$(golint ./... | tee /dev/stderr)"
     - run:
         name: Run tests
         command: go test -v ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,10 @@ jobs:
     - run:
         name: Install dependencies
         command: go mod download
+    - run:
+        name: Install linters
+        command: |
+          go get golang.org/x/tools/cmd/goimports
     - save_cache:
         name: Save go modules cache
         key: mod-{{ .Environment.COMMON_CACHE_KEY }}-{{ checksum "go.mod" }}
@@ -23,6 +27,9 @@ jobs:
     - run:
         name: Exec go vet
         command: go vet ./...
+    - run:
+        name: Exec goimports
+        command: test -z "$(goimports -l . | tee /dev/stderr)"
     - run:
         name: Run tests
         command: go test -v ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
         paths:
         - /go/pkg/mod/cache
     - run:
+        name: Exec go vet
+        command: go vet ./...
+    - run:
         name: Run tests
         command: go test -v ./...
 

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	github.com/pkg/errors v0.8.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2 // indirect
+	golang.org/x/tools v0.0.0-20181115194243-f87c222f1487 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,6 @@ require (
 	github.com/pkg/errors v0.8.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2 // indirect
+	golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 // indirect
 	golang.org/x/tools v0.0.0-20181115194243-f87c222f1487 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,3 +14,5 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/tools v0.0.0-20181115194243-f87c222f1487 h1:o+NPJYn9vdNYpiKcEkvl0q2zlL6QJash01eEk2l/OPc=
+golang.org/x/tools v0.0.0-20181115194243-f87c222f1487/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/go.sum
+++ b/go.sum
@@ -14,5 +14,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 h1:x/bBzNauLQAlE3fLku/xy92Y8QwKX5HZymrMz2IiKFc=
+golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/tools v0.0.0-20181115194243-f87c222f1487 h1:o+NPJYn9vdNYpiKcEkvl0q2zlL6QJash01eEk2l/OPc=
 golang.org/x/tools v0.0.0-20181115194243-f87c222f1487/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/slack.go
+++ b/slack.go
@@ -7,10 +7,12 @@ import (
 	"github.com/nlopes/slack"
 )
 
+// SlackRequester is interface that wrap slack.Client only methods this package needs
 type SlackRequester interface {
 	SearchMessagesContext(context.Context, string, slack.SearchParameters) (*slack.SearchMessages, error)
 }
 
+// SlackClient is api client for slack request
 type SlackClient struct {
 	Client SlackRequester
 }


### PR DESCRIPTION
add static analytics at CircleCI

* go vet
* goimports
* golint

When `go vet` failed
---

![image](https://user-images.githubusercontent.com/21254456/48611304-5810e280-e9c9-11e8-81b8-1da6dc458f37.png)
https://circleci.com/gh/crowdworks/slacts/21

When `goimports` failed
---

![image](https://user-images.githubusercontent.com/21254456/48611369-7bd42880-e9c9-11e8-9e20-35f49a272c4b.png)
https://circleci.com/gh/crowdworks/slacts/27

When `golint` failed
---

![image](https://user-images.githubusercontent.com/21254456/48611410-8ee6f880-e9c9-11e8-811e-159defc7b55d.png)
https://circleci.com/gh/crowdworks/slacts/29