### PR TITLE
store artifact test result and coverage profile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
     - image: golang:1.11.2
       environment:
         GO111MODULE: "on"
+        TEST_RESULTS: /tmp/test-results
     steps:
     - checkout
     - restore_cache:
@@ -20,6 +21,7 @@ jobs:
         command: |
           go get golang.org/x/tools/cmd/goimports
           go get golang.org/x/lint/golint
+          go get github.com/jstemmer/go-junit-report
     - save_cache:
         name: Save go modules cache
         key: mod-{{ .Environment.COMMON_CACHE_KEY }}-{{ checksum "go.mod" }}
@@ -36,8 +38,15 @@ jobs:
         command: test -z "$(golint ./... | tee /dev/stderr)"
     - run:
         name: Run tests
-        command: go test -v ./...
-
+        command: |
+          mkdir -p ${TEST_RESULTS}
+          trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
+          go test -v ./... | tee ${TEST_RESULTS}/go-test.out
+    - store_artifacts: # Upload test summary for display in Artifacts
+        path: /tmp/test-results
+        destination: raw-test-output
+    - store_test_results:
+        path: /tmp/test-results
 workflows:
   version: 2
   default:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,9 @@ jobs:
         command: |
           mkdir -p ${TEST_RESULTS}
           trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
-          go test -v ./... | tee ${TEST_RESULTS}/go-test.out
-    - store_artifacts: # Upload test summary for display in Artifacts
+          go test -coverprofile ${TEST_RESULTS}/coverprofile -v ./... | tee ${TEST_RESULTS}/go-test.out
+          go tool cover -html ${TEST_RESULTS}/coverprofile -o ${TEST_RESULTS}/coverprofile.html
+    - store_artifacts:
         path: /tmp/test-results
         destination: raw-test-output
     - store_test_results:

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # JetBrains IDE
 .idea/
+
+coverprofile
+coverprofile.html

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,27 @@
 # https://gist.github.com/tadashi-aikawa/da73d277a3c1ec6767ed48d1335900f3
 .PHONY: $(shell grep -E '^[a-zA-Z_-]+:' $(MAKEFILE_LIST) | sed 's/://')
 
-goimports: ## fix format by goimports
-	goimports -w .
-
 install: ## install slacts command
 	go install github.com/crowdworks/slacts/cmd/slacts
+
+test: ## run tests for all package
+	go test -v ./...
+
+coverage: ## measure tests coverage and generate coverage profile html
+	go test -coverprofile coverprofile -v ./...
+	go tool cover -html coverprofile -o coverprofile.html
+
+govet: ## exec go vet checks all for package
+	go vet ./...
+
+golint: ## exec golint checks all for package
+	golint ./...
+
+goimports: ## exec goimports checks all for package
+	goimports -l .
+
+goimports-fix: ## fix format by goimports
+	goimports -w .
 
 # https://postd.cc/auto-documented-makefile/
 help: ## show help

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # slacts
 
+[![GoDoc](https://godoc.org/github.com/crowdworks/slacts?status.svg)](https://godoc.org/github.com/crowdworks/slacts)
+
 A CLI tool for Slack statistics
 
 ## License

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/crowdworks/slacts
 
 require (
 	github.com/gorilla/websocket v1.4.0 // indirect
+	github.com/jstemmer/go-junit-report v0.0.0-20180614143834-385fac0ced9a // indirect
 	github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5 // indirect
 	github.com/lusis/slack-test v0.0.0-20180109053238-3c758769bfa6 // indirect
 	github.com/mitchellh/go-homedir v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/jstemmer/go-junit-report v0.0.0-20180614143834-385fac0ced9a h1:2qq552JOlVHGYvqPc9ynBnGPDHeA7p0/QRn2NkrO8vk=
+github.com/jstemmer/go-junit-report v0.0.0-20180614143834-385fac0ced9a/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5 h1:AsEBgzv3DhuYHI/GiQh2HxvTP71HCCE9E/tzGUzGdtU=
 github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5/go.mod h1:c2mYKRyMb1BPkO5St0c/ps62L4S0W2NAkaTXj9qEI+0=
 github.com/lusis/slack-test v0.0.0-20180109053238-3c758769bfa6 h1:iOAVXzZyXtW408TMYejlUPo6BIn92HmOacWtIfNyYns=


### PR DESCRIPTION
store artifact test result
---

![image](https://user-images.githubusercontent.com/21254456/48880030-df3eda00-ee51-11e8-8efc-0f223dac6800.png)


store artifact coverage profile
---

![image](https://user-images.githubusercontent.com/21254456/48880044-ecf45f80-ee51-11e8-84d3-5b08ee9656c2.png)

You can see what codes are covered and uncovered by HTML.

https://47-157309659-gh.circle-artifacts.com/0/raw-test-output/coverprofile.html#file0

add tasks to Makefile accordance with ci
---

new available commands are following.

```
$ make
coverage                       measure tests coverage and generate coverage profile html
goimports-fix                  fix format by goimports
goimports                      exec goimports checks all for package
golint                         exec golint checks all for package
govet                          exec go vet checks all for package
test                           run tests for all package
```
