### PR TITLE
introduce codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,14 @@ jobs:
         command: |
           mkdir -p ${TEST_RESULTS}
           trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
-          go test -coverprofile ${TEST_RESULTS}/coverprofile -v ./... | tee ${TEST_RESULTS}/go-test.out
-          go tool cover -html ${TEST_RESULTS}/coverprofile -o ${TEST_RESULTS}/coverprofile.html
+          go test -coverprofile ${TEST_RESULTS}/coverage.txt -v ./... | tee ${TEST_RESULTS}/go-test.out
+          go tool cover -html ${TEST_RESULTS}/coverage.txt -o ${TEST_RESULTS}/coverage.html
+    - run:
+        name: Send result codecov
+        working_directory: jsonrpc
+        command: |
+          cp ${TEST_RESULTS}/coverage.txt .
+          bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}
     - store_artifacts:
         path: /tmp/test-results
         destination: raw-test-output

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # slacts
 
 [![GoDoc](https://godoc.org/github.com/crowdworks/slacts?status.svg)](https://godoc.org/github.com/crowdworks/slacts)
+[![codecov](https://codecov.io/gh/crowdworks/slacts/branch/master/graph/badge.svg)](https://codecov.io/gh/crowdworks/slacts)
 
 A CLI tool for Slack statistics
 


### PR DESCRIPTION
introduce codecov
https://codecov.io/

this service visualizes tests coverage.