### PR TITLE
[WIP] add task command for sending result to datadog

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,2 +1,5 @@
 export GO111MODULE=on
 export SLACK_API_TOKEN=xxxxxxxxxxxxxxxxxxx
+
+export DATADOG_API_KEY=
+export DATADOG_APP_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 coverprofile
 coverprofile.html
+
+slacts.yml

--- a/cmd/slacts/main.go
+++ b/cmd/slacts/main.go
@@ -117,14 +117,10 @@ var slackCountCmd = &cobra.Command{
 	},
 }
 
-func stringPointer(v string) *string {
-	return &v
-}
-
 func float64Pointer(v float64) *float64 {
 	return &v
 }
 
 func main() {
-	rootCmd.Execute()
+	_ = rootCmd.Execute()
 }

--- a/cmd/slacts/main.go
+++ b/cmd/slacts/main.go
@@ -4,25 +4,94 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/crowdworks/slacts"
 	"github.com/crowdworks/slacts/config"
 	"github.com/spf13/cobra"
 )
 
+var (
+	slackConfig *config.SlackClientConfig
+)
+
+func init() {
+	slackConfig = config.NewSlackClientConfig()
+
+	slackCmd.AddCommand(slackCountCmd)
+	rootCmd.AddCommand(taskCmd, slackCmd)
+}
+
 var rootCmd = &cobra.Command{
 	Use:   "slacts",
 	Short: "a CLI tool for Slack statistics",
 }
 
+var taskCmd = &cobra.Command{
+	Use:     "task",
+	Short:   "exec tasks",
+	Args:    cobra.ExactArgs(1),
+	Example: "slacts task slacts.yml",
+	Run: func(cmd *cobra.Command, args []string) {
+		tasks, err := config.ReadYaml(args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for _, task := range *tasks {
+			switch task.Kind {
+			case "count":
+				query := slacts.NewSlackQuery(task.Query)
+
+				if slackConfig.Token() == "" {
+					log.Fatalln("unset Slack API Token")
+				}
+
+				client := slacts.NewSlackClient(slackConfig.Token(), nil)
+				count, err := client.CountQuery(context.Background(), query)
+
+				if err != nil {
+					log.Fatalln(err)
+				}
+
+				log.Printf("name: %s, kind: %s, result: %d\n", task.Name, task.Kind, count)
+
+				if task.DoesSendDatadog() {
+					ddConfig := config.NewDatadogConfig()
+
+					if ddConfig.AppKey() == "" || ddConfig.APIKey() == "" {
+						log.Fatalln("unset Datadog API credentials. Need both API key and application key")
+					}
+
+					ddClient := slacts.NewDatadogClient(ddConfig.APIKey(), ddConfig.AppKey(), nil)
+
+					// TODO: add lacked properties. for example, Unit, Host and etc...
+					metrics := []slacts.DatadogMetric{
+						{
+							Metric: &task.Datadog.Metric,
+							Points: []slacts.DatadogDataPoint{
+								{
+									float64Pointer(float64(time.Now().Unix())),
+									float64Pointer(float64(count)),
+								},
+							},
+							Tags: task.Datadog.Tags,
+						},
+					}
+
+					if err := ddClient.PostMetrics(metrics); err != nil {
+						log.Fatal(err)
+					}
+					log.Println("send metric to datadog successfully")
+				}
+			}
+		}
+	},
+}
+
 var slackCmd = &cobra.Command{
 	Use:   "slack",
 	Short: "commands for Slack",
-}
-
-// SlackCredentialSetter is interface for Slack credentials config
-type SlackCredentialSetter interface {
-	Token() string
 }
 
 var slackCountCmd = &cobra.Command{
@@ -31,14 +100,13 @@ var slackCountCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Example: "slacts slack count \"in:#general message\"",
 	Run: func(cmd *cobra.Command, args []string) {
-		query := args[0]
-		var config SlackCredentialSetter = config.NewSlackClientConfig()
+		query := slacts.NewSlackQuery(args[0])
 
-		if config.Token() == "" {
+		if slackConfig.Token() == "" {
 			log.Fatalln("unset Slack API Token")
 		}
 
-		client := slacts.NewSlackClient(config.Token(), nil)
+		client := slacts.NewSlackClient(slackConfig.Token(), nil)
 		count, err := client.CountQuery(context.Background(), query)
 
 		if err != nil {
@@ -49,9 +117,14 @@ var slackCountCmd = &cobra.Command{
 	},
 }
 
-func main() {
-	slackCmd.AddCommand(slackCountCmd)
+func stringPointer(v string) *string {
+	return &v
+}
 
-	rootCmd.AddCommand(slackCmd)
+func float64Pointer(v float64) *float64 {
+	return &v
+}
+
+func main() {
 	rootCmd.Execute()
 }

--- a/config/datadog.go
+++ b/config/datadog.go
@@ -1,0 +1,28 @@
+package config
+
+// DatadogConfig is config object for datadog api client
+type DatadogConfig struct {
+	// application key
+	appKey string
+
+	// API key
+	apiKey string
+}
+
+// NewDatadogConfig returns DatadogConfig object
+func NewDatadogConfig() *DatadogConfig {
+	return &DatadogConfig{
+		appKey: getStringEnv("DATADOG_APP_KEY", ""),
+		apiKey: getStringEnv("DATADOG_API_KEY", ""),
+	}
+}
+
+// AppKey of Datadog
+func (dc *DatadogConfig) AppKey() string {
+	return dc.appKey
+}
+
+// APIKey of Datadog
+func (dc *DatadogConfig) APIKey() string {
+	return dc.apiKey
+}

--- a/config/datadog_test.go
+++ b/config/datadog_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNewDatadogConfig(t *testing.T) {
+	type envs struct {
+		appKey string
+		apiKey string
+	}
+
+	cases := map[string]struct {
+		envs       envs
+		wantAPIKey string
+		wantAppKey string
+	}{
+		"normal": {
+			envs: envs{
+				appKey: "datadog_app_token",
+				apiKey: "datadog_api_token",
+			},
+			wantAppKey: "datadog_app_token",
+			wantAPIKey: "datadog_api_token",
+		},
+		"not set env": {
+			envs:       envs{},
+			wantAPIKey: "",
+			wantAppKey: "",
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			_ = os.Setenv("DATADOG_APP_KEY", c.envs.appKey)
+			_ = os.Setenv("DATADOG_API_KEY", c.envs.apiKey)
+
+			got := NewDatadogConfig()
+
+			if got.AppKey() != c.wantAppKey {
+				t.Errorf("AppKey() = %s, but want %s", got.AppKey(), c.wantAppKey)
+			}
+
+			if got.APIKey() != c.wantAPIKey {
+				t.Errorf("APIKey() = %s, but want %s", got.APIKey(), c.wantAPIKey)
+			}
+		})
+	}
+}

--- a/config/file.go
+++ b/config/file.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
+var (
+	kinds = []string{"count"}
+)
+
+// TaskConfig define what task should do
+type TaskConfig struct {
+	// Name of task
+	Name string
+
+	// Kind of task. only count is available
+	Kind string
+
+	// Query for slack message search
+	Query string
+
+	// Datadog config for metrics
+	Datadog Datadog
+}
+
+// Datadog config for metrics
+type Datadog struct {
+	Metric string
+	Tags   []string
+}
+
+// ReadYaml of given file path
+func ReadYaml(file string) (*[]TaskConfig, error) {
+	viper.SetConfigFile(file)
+	if err := viper.ReadInConfig(); err != nil {
+		return nil, err
+	}
+
+	var tasks []TaskConfig
+	if err := viper.UnmarshalKey("tasks", &tasks); err != nil {
+		return nil, err
+	}
+
+	for _, task := range tasks {
+		if err := task.validate(); err != nil {
+			return nil, err
+		}
+	}
+
+	return &tasks, nil
+}
+
+func (tc *TaskConfig) validate() error {
+	if err := tc.validateKind(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (tc *TaskConfig) validateKind() error {
+	for _, k := range kinds {
+		if k == tc.Kind {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid kind. available: %v", kinds)
+}
+
+// DoesSendDatadog returns config has datadog config
+func (tc *TaskConfig) DoesSendDatadog() bool {
+	return tc.Datadog.Metric != ""
+}

--- a/config/file_test.go
+++ b/config/file_test.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestReadYaml(t *testing.T) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := map[string]struct {
+		file    string
+		want    []TaskConfig
+		wantErr bool
+	}{
+		"count": {
+			file: filepath.Join(pwd, "./testdata/count.yml"),
+			want: []TaskConfig{
+				{
+					Name:  "test_task",
+					Kind:  "count",
+					Query: "in:#general on:2018/12/03",
+					Datadog: Datadog{
+						Metric: "general.slack.count",
+						Tags:   []string{"from:test", "env:test"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		"undefined kind": {
+			file:    filepath.Join(pwd, "./testdata/no-kind.yml"),
+			want:    nil,
+			wantErr: true,
+		},
+		"not yaml": {
+			file:    filepath.Join(pwd, "./testdata/unformatted.yml"),
+			want:    nil,
+			wantErr: true,
+		},
+		"invalid file path": {
+			file:    filepath.Join(pwd, "./testdata/invalid-file-path"),
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := ReadYaml(c.file)
+			if (err != nil) != c.wantErr {
+				t.Errorf("Read() error = %v, wantErr %v", err, c.wantErr)
+				return
+			}
+
+			if c.wantErr {
+				return
+			}
+
+			if !reflect.DeepEqual(got, &c.want) {
+				t.Errorf("Read() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestTaskConfig_DoesSendDatadog(t *testing.T) {
+	type fields struct {
+		Name    string
+		Kind    string
+		Query   string
+		Datadog Datadog
+	}
+	cases := map[string]struct {
+		fields fields
+		want   bool
+	}{
+		"has datadog config": {
+			fields: fields{
+				Name:  "example",
+				Kind:  "count",
+				Query: "in:#general",
+				Datadog: Datadog{
+					Metric: "sample",
+				},
+			},
+			want: true,
+		},
+		"empty datadog config": {
+			fields: fields{
+				Name:    "example",
+				Kind:    "count",
+				Query:   "in:#general",
+				Datadog: Datadog{},
+			},
+			want: false,
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc := &TaskConfig{
+				Name:    c.fields.Name,
+				Kind:    c.fields.Kind,
+				Query:   c.fields.Query,
+				Datadog: c.fields.Datadog,
+			}
+			if got := tc.DoesSendDatadog(); got != c.want {
+				t.Errorf("TaskConfig.DoesSendDatadog() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/config/testdata/count.yml
+++ b/config/testdata/count.yml
@@ -1,0 +1,9 @@
+tasks:
+  - name: "test_task"
+    kind: "count"
+    query: "in:#general on:2018/12/03"
+    datadog:
+      metric: "general.slack.count"
+      tags:
+        - "from:test"
+        - "env:test"

--- a/config/testdata/no-kind.yml
+++ b/config/testdata/no-kind.yml
@@ -1,0 +1,8 @@
+tasks:
+  - name: "test_task"
+    query: "in:#general on:2018/12/03"
+    datadog:
+      metric: "general.slack.count"
+      tags:
+        - "from:test"
+        - "env:test"

--- a/config/testdata/unformatted.yml
+++ b/config/testdata/unformatted.yml
@@ -1,0 +1,1 @@
+I'm not yaml

--- a/datadog.go
+++ b/datadog.go
@@ -1,0 +1,44 @@
+package slacts
+
+import (
+	"net/http"
+
+	datadog "github.com/zorkian/go-datadog-api"
+)
+
+// DatadogMetric is alias of datadog.Metric
+type DatadogMetric = datadog.Metric
+
+// DatadogDataPoint is alias of datadog.DataPoint
+type DatadogDataPoint = datadog.DataPoint
+
+// DatadogRequester is interface of Datadog API client library
+type DatadogRequester interface {
+	PostMetrics([]DatadogMetric) error
+}
+
+// DatadogClient is client of Datadog API
+type DatadogClient struct {
+	Client DatadogRequester
+}
+
+// NewDatadogClient returns Datadog API client
+func NewDatadogClient(apiKey, appKey string, httpclient *http.Client) *DatadogClient {
+	client := datadog.NewClient(apiKey, appKey)
+	if httpclient != nil {
+		client.HttpClient = httpclient
+	}
+
+	return &DatadogClient{
+		Client: client,
+	}
+}
+
+// PostMetrics to datadog
+func (dc *DatadogClient) PostMetrics(metrics []DatadogMetric) error {
+	if err := dc.Client.PostMetrics(metrics); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/datadog.go
+++ b/datadog.go
@@ -3,6 +3,8 @@ package slacts
 import (
 	"net/http"
 
+	"github.com/pkg/errors"
+
 	datadog "github.com/zorkian/go-datadog-api"
 )
 
@@ -36,6 +38,10 @@ func NewDatadogClient(apiKey, appKey string, httpclient *http.Client) *DatadogCl
 
 // PostMetrics to datadog
 func (dc *DatadogClient) PostMetrics(metrics []DatadogMetric) error {
+	if metrics == nil || len(metrics) == 0 {
+		return errors.New("no metrics given")
+	}
+
 	if err := dc.Client.PostMetrics(metrics); err != nil {
 		return err
 	}

--- a/datadog_test.go
+++ b/datadog_test.go
@@ -1,0 +1,120 @@
+package slacts_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/crowdworks/slacts"
+)
+
+type testDatadogClient struct {
+	hasError bool
+}
+
+func (tdc *testDatadogClient) PostMetrics(metrics []slacts.DatadogMetric) error {
+	if tdc.hasError {
+		return errors.New("some error occurred")
+	}
+
+	return nil
+}
+
+func TestDatadogClient_PostMetrics(t *testing.T) {
+	type fields struct {
+		Client slacts.DatadogRequester
+	}
+	type args struct {
+		metrics []slacts.DatadogMetric
+	}
+	cases := map[string]struct {
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		"normal": {
+			fields: fields{
+				Client: &testDatadogClient{
+					hasError: false,
+				},
+			},
+			args: args{
+				metrics: []slacts.DatadogMetric{
+					{
+						Metric: stringPointer("test.post.metric"),
+						Points: []slacts.DatadogDataPoint{
+							{
+								float64Pointer(float64(time.Now().Unix())),
+								float64Pointer(3.0),
+							},
+						},
+						Tags: []string{"env:test", "channel:general"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		"nil metric": {
+			fields: fields{
+				Client: &testDatadogClient{
+					hasError: false,
+				},
+			},
+			args: args{
+				metrics: nil,
+			},
+			wantErr: true,
+		},
+		"empty metric": {
+			fields: fields{
+				Client: &testDatadogClient{
+					hasError: false,
+				},
+			},
+			args: args{
+				metrics: []slacts.DatadogMetric{},
+			},
+			wantErr: true,
+		},
+		"some server error": {
+			fields: fields{
+				Client: &testDatadogClient{
+					hasError: true,
+				},
+			},
+			args: args{
+				metrics: []slacts.DatadogMetric{
+					{
+						Metric: stringPointer("test.post.metric"),
+						Points: []slacts.DatadogDataPoint{
+							{
+								float64Pointer(float64(time.Now().Unix())),
+								float64Pointer(3.0),
+							},
+						},
+						Tags: []string{"env:test", "channel:general"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			dc := &slacts.DatadogClient{
+				Client: c.fields.Client,
+			}
+			if err := dc.PostMetrics(c.args.metrics); (err != nil) != c.wantErr {
+				t.Errorf("DatadogClient.PostMetrics() error = %v, wantErr %v", err, c.wantErr)
+			}
+		})
+	}
+}
+
+func stringPointer(v string) *string {
+	return &v
+}
+
+func float64Pointer(v float64) *float64 {
+	return &v
+}

--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,20 @@
 module github.com/crowdworks/slacts
 
 require (
+	github.com/cenkalti/backoff v2.1.0+incompatible // indirect
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/jstemmer/go-junit-report v0.0.0-20180614143834-385fac0ced9a // indirect
 	github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5 // indirect
 	github.com/lusis/slack-test v0.0.0-20180109053238-3c758769bfa6 // indirect
 	github.com/mitchellh/go-homedir v1.0.0 // indirect
 	github.com/nlopes/slack v0.4.0
-	github.com/pkg/errors v0.8.0 // indirect
+	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
-	github.com/spf13/viper v1.2.1 // indirect
+	github.com/spf13/viper v1.2.1
 	github.com/stretchr/testify v1.2.2 // indirect
+	github.com/zorkian/go-datadog-api v2.18.0+incompatible
 	golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 // indirect
 	golang.org/x/tools v0.0.0-20181115194243-f87c222f1487 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/cenkalti/backoff v2.1.0+incompatible h1:FIRvWBZrzS4YC7NT5cOuZjexzFvIr+Dbi6aD1cZaNBk=
+github.com/cenkalti/backoff v2.1.0+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -41,6 +43,8 @@ github.com/spf13/viper v1.2.1 h1:bIcUwXqLseLF3BDAZduuNfekWG87ibtFxi59Bq+oI9M=
 github.com/spf13/viper v1.2.1/go.mod h1:P4AexN0a+C9tGAnUFNwDMYYZv3pjFuvmeiMyKRaNVlI=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/zorkian/go-datadog-api v2.18.0+incompatible h1:7JZOVDO8qDaXDKPAzTgiJahU3IoDyzxbLDwoT0U9n0w=
+github.com/zorkian/go-datadog-api v2.18.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 h1:x/bBzNauLQAlE3fLku/xy92Y8QwKX5HZymrMz2IiKFc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/sys v0.0.0-20180906133057-8cf3aee42992 h1:BH3eQWeGbwRU2+wxxuuPOdFBmaiBH81O8BugSjHeTFg=

--- a/slack_test.go
+++ b/slack_test.go
@@ -54,7 +54,7 @@ func TestSlackClient_CountQuery(t *testing.T) {
 				Client: c.client,
 			}
 
-			count, err := sc.CountQuery(ctx, "in:#general channel")
+			count, err := sc.CountQuery(ctx, slacts.NewSlackQuery("in:#general channel"))
 
 			if c.expectError {
 				if err == nil {
@@ -123,6 +123,46 @@ func TestNewSlackClient(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			if got := slacts.NewSlackClient(c.args.token, c.args.httpclient); !reflect.DeepEqual(got, c.want) {
 				t.Errorf("NewSlackClient() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestSlackQuery_Date(t *testing.T) {
+	cases := map[string]struct {
+		q       *slacts.SlackQuery
+		want    time.Time
+		wantErr bool
+	}{
+		"only date": {
+			q:       slacts.NewSlackQuery("on:2018/02/28"),
+			want:    time.Date(2018, 2, 28, 0, 0, 0, 0, time.UTC),
+			wantErr: false,
+		},
+		"with other query": {
+			q:       slacts.NewSlackQuery("in:#general on:2018/02/28 @channel"),
+			want:    time.Date(2018, 2, 28, 0, 0, 0, 0, time.UTC),
+			wantErr: false,
+		},
+		"no date in query": {
+			q:       slacts.NewSlackQuery("in:#general @channel"),
+			wantErr: true,
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := c.q.Date()
+			if (err != nil) != c.wantErr {
+				t.Errorf("SlackQuery.Date() error = %v, wantErr %v", err, c.wantErr)
+				return
+			}
+
+			if c.wantErr {
+				return
+			}
+
+			if !reflect.DeepEqual(got, &c.want) {
+				t.Errorf("SlackQuery.Date() = %v, want %v", got, c.want)
 			}
 		})
 	}

--- a/slack_test.go
+++ b/slack_test.go
@@ -144,6 +144,10 @@ func TestSlackQuery_Date(t *testing.T) {
 			want:    time.Date(2018, 2, 28, 0, 0, 0, 0, time.UTC),
 			wantErr: false,
 		},
+		"wrong date format": {
+			q:       slacts.NewSlackQuery("in:#general on:2018/22/28 @channel"),
+			wantErr: true,
+		},
 		"no date in query": {
 			q:       slacts.NewSlackQuery("in:#general @channel"),
 			wantErr: true,


### PR DESCRIPTION
Add `task` command.

`task` command be able to execute with reading configuration yaml because it needs many configuration for sending datadog.

For example,

```
$ slacts task slacts.yml
```

example is following

```yaml
tasks:
  - name: "test_task"
    kind: "count"
    query: "in:#general on:2018/12/03"
    datadog:
      metric: "general.slack.count"
      tags:
        - "from:test"
        - "env:test"
```

### Precondition

Slack and Datadog credentials are set in environment variable.