### PR TITLE
fix command line args name count

### DIFF
--- a/cmd/slacts/main.go
+++ b/cmd/slacts/main.go
@@ -36,6 +36,9 @@ type taskFilter struct {
 }
 
 func (f *taskFilter) names() []string {
+	if strings.TrimSpace(f.namesStr) == "" {
+		return nil
+	}
 	return strings.Split(f.namesStr, ",")
 }
 


### PR DESCRIPTION
bug fix for `task` command argument

AsIs
---

when give no `--name` arguments, length is 1

ToBe
---

when give no `--name` arguments, length is 0