### PR TITLE
docker: Bump Go to v1.12 from v1.11.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-    - image: golang:1.11.4
+    - image: golang:1.12
       environment:
         GO111MODULE: "on"
         TEST_RESULTS: /tmp/test-results
@@ -56,12 +56,10 @@ jobs:
         path: /tmp/test-results
   docker-build:
     docker:
-    - image: docker:18.05.0
+    - image: circleci/python
     steps:
     - checkout
-    - setup_remote_docker:
-        version: 18.05.0-ce
-        docker_layer_caching: true
+    - setup_remote_docker
     - run:
         name: build
         command: docker build --no-cache -t slacts:latest .

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,2 +1,5 @@
 ignored:
   - DL4006
+  # version pinning
+  # in case of failing to download packages after a long time
+  - DL3018

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 # Builder container
 ###############################
 
-FROM golang:1.11.4-alpine3.8 AS builder
+FROM golang:1.12-alpine AS builder
 ENV GO111MODULE=on
 
 WORKDIR /go/src/github.com/crowdworks/slacts
 COPY . .
 
 RUN set -x \
-  && apk add --no-cache git="2.18.1-r0" build-base="0.5-r1" \
+  && apk add --no-cache git build-base \
   && go mod download \
   && go mod verify \
   && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo -installsuffix netgo  -o ./slacts ./cmd/slacts/main.go
@@ -18,12 +18,12 @@ RUN set -x \
 # Exec container
 ###############################
 
-FROM alpine:3.8
+FROM alpine:3.10
 
 ENV APP_DIR /usr/src/app
 
 RUN set -x \
-    && apk add --no-cache ca-certificates="20171114-r3" \
+    && apk add --no-cache ca-certificates \
     && adduser -S slacts \
     && echo "slacts:slacts" | chpasswd \
     && addgroup -S slacts \


### PR DESCRIPTION
Bump Go version to v1.12 from v1.11.4 and alpine to v3.10 from v3.8.

And... all packages in Dockerfile had pinned version for hadlint. But when I built image after long time, building image went failed because they were no longer unavailable.
So I abandoned pinned version at Dockerfile.