### PR TITLE
Add ca-certificates in Dockerfile

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -2,4 +2,4 @@ ignored:
   - DL4006
   # version pinning
   # in case of failing to download packages after a long time
-  - DL3018
+  - DL3008

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ FROM debian:bullseye-slim
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* \
-  && update-ca-certificates
+  && rm -rf /var/lib/apt/lists/*
 
 ENV APP_DIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,12 @@ RUN make install
 
 FROM debian:bullseye-slim
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && update-ca-certificates
+
 ENV APP_DIR /usr/src/app
 
 RUN set -x \


### PR DESCRIPTION
Starting from #40, we switched the base image to Debian, but the debian:bullseye-slim image doesn't have ca-certificates by default. This causes the following error:

> failed to search message API request: Post "https://slack.com/api/search.messages": x509: certificate signed by unknown authority

To fix the issue, add the ca-certificates package and run update-ca-certificates in Dockerfile.

I also fixed the hadolint configuration which depends on Alpine.

DL3018 is for apk add (Alpine)
https://github.com/hadolint/hadolint/wiki/DL3018

DL3008 is for apt-get install (Debian)
https://github.com/hadolint/hadolint/wiki/DL3008